### PR TITLE
Fix liveunderstanding

### DIFF
--- a/Source/Wit/Private/Voice/Experience/VoiceExperience.cpp
+++ b/Source/Wit/Private/Voice/Experience/VoiceExperience.cpp
@@ -221,7 +221,7 @@ void AVoiceExperience::SendTranscriptionWithRequestOptions(const FString& Text, 
  * @param Response [in] the Partial Response to accept, this will be used as final response to call onResponse.
  * 
  */
-void AVoiceExperience::AcceptPartialResponseAndCancelRequest(const FWitResponse& Response) const
+void AVoiceExperience::AcceptPartialResponseAndCancelRequest(const FWitResponse& Response)
 {
 	if (VoiceService != nullptr)
 	{

--- a/Source/Wit/Private/Voice/Matcher/VoiceResponseMatcher.cpp
+++ b/Source/Wit/Private/Voice/Matcher/VoiceResponseMatcher.cpp
@@ -37,7 +37,7 @@ void UVoiceResponseMatcher::BeginPlay()
 		return;
 	}
 
-	UE_LOG(LogWit, Verbose, TEXT("UVoiceIntentMatcher: Registering response callback"));
+	UE_LOG(LogWit, Verbose, TEXT("UVoiceResponseMatcher: Registering response callback"));
 
 	VoiceExperience->VoiceEvents->OnWitResponse.AddUniqueDynamic(this, &UVoiceResponseMatcher::OnWitResponse);
 		
@@ -59,13 +59,13 @@ void UVoiceResponseMatcher::AcceptPartialResponse(const FWitResponse& Response)
 		return;
 	}
 	
-	UE_LOG(LogWit, Verbose, TEXT("UVoiceIntentMatcher: the partial response matched the intent and confidence threshold"));
+	UE_LOG(LogWit, Verbose, TEXT("UVoiceResponseMatcher: the partial responhe partial response matched the intent and confidence threshold"));
 
 	bool bShouldAcceptPartialResponse = false;
 	
 	if (bAutoAcceptPartialResponseOncePastMatcherCriteria)
 	{
-		UE_LOG(LogWit, Display, TEXT("UVoiceIntentMatcher: auto accept is on - accepting the partial response"));
+		UE_LOG(LogWit, Display, TEXT("UVoiceResponseMatcher: auto accept is on - accepting the partial response"));
 
 		bShouldAcceptPartialResponse = true;
 	}
@@ -78,7 +78,7 @@ void UVoiceResponseMatcher::AcceptPartialResponse(const FWitResponse& Response)
 		
 		if (PartialResponseValidatorInstance != nullptr && IWitPartialResponseValidator::Execute_ValidatePartialResponse(PartialResponseValidatorInstance, Response))
 		{
-			UE_LOG(LogWit, Display, TEXT("UVoiceIntentMatcher: partial response validator is supplied and validated - accepting the partial response"));
+			UE_LOG(LogWit, Display, TEXT("UVoiceResponseMatcher: partial response validator is supplied and validated - accepting the partial response"));
 
 			bShouldAcceptPartialResponse = true;
 		}

--- a/Source/Wit/Private/Wit/Request/WitResponse.cpp
+++ b/Source/Wit/Private/Wit/Request/WitResponse.cpp
@@ -16,4 +16,5 @@ void FWitResponse::Reset()
     Intents.Empty(0);
     Entities.Empty(0);
     Traits.Empty(0);
+	Is_Final = false;
 }

--- a/Source/Wit/Private/Wit/Request/WitResponse.cpp
+++ b/Source/Wit/Private/Wit/Request/WitResponse.cpp
@@ -13,8 +13,8 @@
 void FWitResponse::Reset()
 {
 	Text.Empty(0);
-    Intents.Empty(0);
-    Entities.Empty(0);
-    Traits.Empty(0);
+	Intents.Empty(0);
+	Entities.Empty(0);
+	Traits.Empty(0);
 	Is_Final = false;
 }

--- a/Source/Wit/Private/Wit/Utilities/WitHelperUtilities.cpp
+++ b/Source/Wit/Private/Wit/Utilities/WitHelperUtilities.cpp
@@ -299,7 +299,7 @@ bool FWitHelperUtilities::ConvertJsonToWitResponse(const TSharedPtr<FJsonObject>
 
 void FWitHelperUtilities::AcceptPartialResponseAndCancelRequest(const UWorld* World, const FName& Tag, const FWitResponse& Response)
 {
-	const AVoiceExperience* VoiceExperience = FWitHelperUtilities::FindVoiceExperience(World, Tag);
+	AVoiceExperience* VoiceExperience = FWitHelperUtilities::FindVoiceExperience(World, Tag);
 	
 	if (VoiceExperience == nullptr)
 	{

--- a/Source/Wit/Private/Wit/Voice/WitVoiceService.cpp
+++ b/Source/Wit/Private/Wit/Voice/WitVoiceService.cpp
@@ -647,6 +647,8 @@ void UWitVoiceService::AcceptPartialResponseAndCancelRequest(const FWitResponse&
 	}
 
 	RequestSubsystem->CancelRequest();
+	
+	 const_cast<UWitVoiceService*>(this)->DeactivateVoiceInput();
 
 	FWitResponse FinalResponse = Response;
 	FinalResponse.Is_Final = true;
@@ -693,6 +695,8 @@ void UWitVoiceService::OnPartialResponse(const TArray<uint8>& PartialBinaryRespo
 		return;		
 	}
 	
+	Events->WitResponse.Reset();
+	
 	const bool bIsConversionError = !FWitHelperUtilities::ConvertJsonToWitResponse(PartialJsonResponse.ToSharedRef(), &Events->WitResponse);
 	
 	if (bIsConversionError)
@@ -717,7 +721,8 @@ void UWitVoiceService::OnSpeechRequestComplete(const TArray<uint8>& BinaryRespon
 		return;		
 	}
 	
-	Events->WitResponse.Is_Final = false;
+	Events->WitResponse.Reset();
+	
 	const bool bIsConversionError = !FWitHelperUtilities::ConvertJsonToWitResponse(JsonResponse.ToSharedRef(), &Events->WitResponse);
 	if (bIsConversionError)
 	{

--- a/Source/Wit/Private/Wit/Voice/WitVoiceService.cpp
+++ b/Source/Wit/Private/Wit/Voice/WitVoiceService.cpp
@@ -717,6 +717,7 @@ void UWitVoiceService::OnSpeechRequestComplete(const TArray<uint8>& BinaryRespon
 		return;		
 	}
 	
+	Events->WitResponse.Is_Final = false;
 	const bool bIsConversionError = !FWitHelperUtilities::ConvertJsonToWitResponse(JsonResponse.ToSharedRef(), &Events->WitResponse);
 	if (bIsConversionError)
 	{

--- a/Source/Wit/Private/Wit/Voice/WitVoiceService.cpp
+++ b/Source/Wit/Private/Wit/Voice/WitVoiceService.cpp
@@ -636,7 +636,7 @@ void UWitVoiceService::SendTranscriptionWithRequestOptions(const FString& Text, 
  *
  * @param Response [in] the Partial Response to accept, this will be used as final response to call onResponse.
  */
-void UWitVoiceService::AcceptPartialResponseAndCancelRequest(const FWitResponse& Response) const
+void UWitVoiceService::AcceptPartialResponseAndCancelRequest(const FWitResponse& Response)
 {
 	UWitRequestSubsystem* RequestSubsystem = GEngine->GetEngineSubsystem<UWitRequestSubsystem>();
 
@@ -647,8 +647,8 @@ void UWitVoiceService::AcceptPartialResponseAndCancelRequest(const FWitResponse&
 	}
 
 	RequestSubsystem->CancelRequest();
-	
-	 const_cast<UWitVoiceService*>(this)->DeactivateVoiceInput();
+
+	DeactivateVoiceInput();
 
 	FWitResponse FinalResponse = Response;
 	FinalResponse.Is_Final = true;

--- a/Source/Wit/Public/Voice/Experience/VoiceExperience.h
+++ b/Source/Wit/Public/Voice/Experience/VoiceExperience.h
@@ -87,7 +87,7 @@ public:
 	virtual void SendTranscriptionWithRequestOptions(const FString& Text, const FString& RequestOptions) override;
 
 	UFUNCTION(BlueprintCallable, BlueprintPure=false, Category = "Voice Experience")
-	virtual void AcceptPartialResponseAndCancelRequest(const FWitResponse& Response) const override;
+	virtual void AcceptPartialResponseAndCancelRequest(const FWitResponse& Response) override;
 
 protected:
 

--- a/Source/Wit/Public/Voice/Service/Interface/IVoiceServiceBase.h
+++ b/Source/Wit/Public/Voice/Service/Interface/IVoiceServiceBase.h
@@ -115,6 +115,6 @@ public:
 	 *
 	 * @param Response [in] the Partial Response to accept, this will be used as final response to call onResponse.
 	 */
-	virtual void AcceptPartialResponseAndCancelRequest(const FWitResponse& Response) const = 0;
+	virtual void AcceptPartialResponseAndCancelRequest(const FWitResponse& Response) = 0;
 
 };

--- a/Source/Wit/Public/Voice/Service/VoiceService.h
+++ b/Source/Wit/Public/Voice/Service/VoiceService.h
@@ -52,7 +52,7 @@ public:
 	virtual bool IsRequestInProgress() const override { return false; }
 	virtual void SendTranscription(const FString& Text) override {}
 	virtual void SendTranscriptionWithRequestOptions(const FString& Text, const FString& RequestOptions) override {}
-	virtual void AcceptPartialResponseAndCancelRequest(const FWitResponse& Response) const override {}
+	virtual void AcceptPartialResponseAndCancelRequest(const FWitResponse& Response) override {}
 
 protected:
 

--- a/Source/Wit/Public/Wit/Voice/WitVoiceService.h
+++ b/Source/Wit/Public/Wit/Voice/WitVoiceService.h
@@ -48,7 +48,7 @@ public:
 	virtual bool IsRequestInProgress() const override;
 	virtual void SendTranscription(const FString& Text) override;
 	virtual void SendTranscriptionWithRequestOptions(const FString& Text, const FString& RequestOptions) override;
-	virtual void AcceptPartialResponseAndCancelRequest(const FWitResponse& Response) const override;
+	virtual void AcceptPartialResponseAndCancelRequest(const FWitResponse& Response) override;
 
 protected:
 	


### PR DESCRIPTION
added Is_Final = false; into reset(). but reset only get called in Error callback. 

So set Is_Final = false; before Json converting.   I feel we should call reset() here as well.