### PR TITLE
fix compiling error for ue4

### DIFF
--- a/Source/Wit/Private/Voice/Capture/Emulation/VoiceCaptureEmulation.cpp
+++ b/Source/Wit/Private/Voice/Capture/Emulation/VoiceCaptureEmulation.cpp
@@ -63,7 +63,7 @@ bool FVoiceCaptureEmulation::Start()
         {
 			bHasPreviewSampleData = false;
 			
-			const FAudioDevice * AudioDevice = GEngine ? GEngine->GetMainAudioDeviceRaw() : nullptr;
+			FAudioDevice * AudioDevice = GEngine ? GEngine->GetMainAudioDeviceRaw() : nullptr;
 
 			if (AudioDevice == nullptr)
 			{


### PR DESCRIPTION
FAudioDevice * AudioDevice cannot be const, otherwise UE4 cannot compile it.

It is ok to be const on UE5.