### PR TITLE
UserAgent logging refactor

### DIFF
--- a/Source/Wit/Private/Wit/Request/HTTP/WitHttpRequest.h
+++ b/Source/Wit/Private/Wit/Request/HTTP/WitHttpRequest.h
@@ -67,7 +67,6 @@ public:
 	/*
 	 * User agent for Wit
 	 */
-	static const FString WitSdkVersion;
 	static FString GetUserAgent();
 
 private:

--- a/Source/Wit/Private/WitModule.cpp
+++ b/Source/Wit/Private/WitModule.cpp
@@ -7,6 +7,7 @@
 
 #include "WitModule.h"
 #include "Curl/CurlHttpManager.h"
+#include "Interfaces/IPluginManager.h"
 #include "Misc/EngineVersionComparison.h"
 #include "Modules/ModuleManager.h"
 #include "Wit/Utilities/WitLog.h"
@@ -14,6 +15,8 @@
 #define LOCTEXT_NAMESPACE "FWitModule"
 
 IMPLEMENT_MODULE(FWitModule, Wit)
+
+const FString FWitModule::Name = "Wit";
 
 FWitModule* FWitModule::Singleton = nullptr;
 
@@ -31,6 +34,19 @@ void FWitModule::StartupModule()
 
 		HttpManager = new FCurlHttpManager();
 		HttpManager->Initialize();
+	}
+
+	// find version code
+	IPluginManager& PluginManager = IPluginManager::Get();
+	TArray<TSharedRef<IPlugin>> Plugins = PluginManager.GetDiscoveredPlugins();
+	for (const TSharedRef<IPlugin>& Plugin : Plugins)
+	{
+		if (Plugin->GetName() == Name)
+		{
+			const FPluginDescriptor& Descriptor = Plugin->GetDescriptor();
+			Version = Descriptor.VersionName;
+			break;
+		}
 	}
 }
 
@@ -61,7 +77,7 @@ FWitModule& FWitModule::Get()
 	if (Singleton == nullptr)
 	{
 		check(IsInGameThread());
-		FModuleManager::LoadModuleChecked<FWitModule>("Wit");
+		FModuleManager::LoadModuleChecked<FWitModule>(*Name);
 	}
 	
 	check(Singleton != nullptr);

--- a/Source/Wit/Public/Wit/Utilities/WitHelperUtilities.cpp
+++ b/Source/Wit/Public/Wit/Utilities/WitHelperUtilities.cpp
@@ -16,6 +16,28 @@
 #include "HAL/PlatformFileManager.h"
 #include "UObject/SavePackage.h"
 
+FString FWitHelperUtilities::AdditionalFrontUserData = "";
+FString FWitHelperUtilities::AdditionalEndUserData = "";
+
+ /**
+  * Adds a string to the user agent data to include in Wit web requests
+  */
+void FWitHelperUtilities::AddRequestUserData(const FString& UserData, const bool AddToFront)
+{
+	if (AddToFront)
+	{
+		AdditionalFrontUserData = AdditionalFrontUserData == ""
+			? FString::Printf(TEXT("%s,"), *UserData)
+			: FString::Printf(TEXT("%s%s,"), *AdditionalFrontUserData, *UserData);
+	}
+	else
+	{
+		AdditionalEndUserData = AdditionalEndUserData == ""
+			? FString::Printf(TEXT(",%s"), *UserData)
+			: FString::Printf(TEXT("%s,%s"), *AdditionalEndUserData, *UserData);
+	}
+}
+
 /**
  * Finds the VoiceExperience in the scene. This is slow so do not call every frame
  * 

--- a/Source/Wit/Public/Wit/Utilities/WitHelperUtilities.h
+++ b/Source/Wit/Public/Wit/Utilities/WitHelperUtilities.h
@@ -19,6 +19,7 @@ struct FWitResponse;
 class UWitVoiceService;
 class AWitVoiceExperience;
 class FJsonObject;
+class FWitHttpRequest;
 
 /**
  * A helper class that contains useful API utilities
@@ -26,6 +27,13 @@ class FJsonObject;
 class WIT_API FWitHelperUtilities
 {
 public:
+
+	friend class FWitHttpRequest;
+
+	/**
+	 * Adds a string to the user agent data to include in Wit web requests
+	 */
+	static void AddRequestUserData(const FString& UserData, const bool AddToFront = false);
 
 	/**
 	 * Finds the VoiceExperience in the scene. This is slow so do not call every frame
@@ -145,4 +153,12 @@ public:
 	 * @param Response [in] the Parity Response to accept. It later will be used for final response.
 	 */
 	static void AcceptPartialResponseAndCancelRequest(const UWorld* World, const FName& Tag, const FWitResponse& Response);
+
+private:
+
+	/** Additional user data to add to the front of user agent data in Wit requests */
+	static FString AdditionalFrontUserData;
+
+	/** Additional user data to add to the end of user agent data in Wit requests */
+	static FString AdditionalEndUserData;
 };

--- a/Source/Wit/Public/WitModule.h
+++ b/Source/Wit/Public/WitModule.h
@@ -19,6 +19,16 @@ class FWitModule final : public IModuleInterface
 public:
 
 	/**
+	 * Voice SDK name
+	 */
+	static const FString Name;
+
+	/**
+	 * Wit API version
+	 */
+	const FString& SdkVersion = Version;
+
+	/**
 	 * IModuleInterface implementation
 	 */
 	virtual void StartupModule() override;
@@ -47,6 +57,9 @@ private:
 
 	/** Keeps track of Http requests while they are being processed */
 	FHttpManager* HttpManager{nullptr};
+
+	/** Wit API version */
+	FString Version;
 
 	/** Singleton for the module while loaded and available */
 	static FWitModule* Singleton;

--- a/Source/Wit/Wit.Build.cs
+++ b/Source/Wit/Wit.Build.cs
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 using System.IO;
 using UnrealBuildTool;
 
@@ -29,7 +28,6 @@ public class Wit : ModuleRules
 		PrivateDefinitions.Add("WITH_CURL_XCURL=0");
 		PrivateDefinitions.Add("WITH_CURL=" + (bPlatformSupportsLibCurl ? "1" : "0"));
 		PrivateDefinitions.Add("WITH_SSL=1");
-		PrivateDefinitions.Add("WITH_VOICESDK_USERAGENT=0");
 		
 		PublicIncludePaths.AddRange(
 			new string[]
@@ -72,6 +70,7 @@ public class Wit : ModuleRules
 				"SSL",
 				"OpenSSL",
 				"libcurl",
+				"Projects",
 				"Sockets",
 				"SignalProcessing"
 			}


### PR DESCRIPTION
- enable voice sdk define by default for now
- use session id instead of request id
- construct best guess bundle id
-  remaining user agent data

Example From Headset: voicesdk-unreal-49.0.1,wit-unreal-49.0.1,"Android-12","Oculus|Quest|QualcommTechnologies,IncKONA",B888EF91426C2FD4F5C925A80A081E57,com.Meta.voicesdk_unreal_demo,Runtime,4.27.2

Example From Editor: voicesdk-unreal-49.0.1,wit-unreal-49.0.1,"Windows-10.0.19045.1.256.64bit","GenuineIntel|Intel(R)Core(TM)i7-10750HCPU@2.60GHz",C6C3C9D74AE98762558677BF627B5666,com.Meta.voicesdk_unreal_demo,Editor,4.27.2