### PR TITLE
Fix crashes on background

### DIFF
--- a/Source/Wit/Private/Voice/Capture/VoiceCaptureSubsystem.cpp
+++ b/Source/Wit/Private/Voice/Capture/VoiceCaptureSubsystem.cpp
@@ -434,7 +434,8 @@ void UVoiceCaptureSubsystem::OnApplicationWillEnterBackground()
 {
 	UE_LOG(LogWit, Verbose, TEXT("VoiceCapture - OnApplicationWillEnterBackground"));
 
-	Shutdown();
+	Stop();
+	VoiceCapture.Reset();
 }
 
 /**


### PR DESCRIPTION
Instead of shutting down the VoiceModule on background, call Stop and reset the Module for future use.