### PR TITLE
Allow PCM responses for TTS

### DIFF
--- a/Source/Wit/Private/TTS/Experience/TtsExperience.cpp
+++ b/Source/Wit/Private/TTS/Experience/TtsExperience.cpp
@@ -42,7 +42,7 @@ void ATtsExperience::InitializeService()
 	if (TtsService != nullptr)
 	{
 		TtsService->SetHandlers(EventHandler, MemoryCacheHandler, StorageCacheHandler);
-		TtsService->SetConfiguration(Configuration, VoicePreset);
+		TtsService->SetConfiguration(Configuration, VoicePreset, AudioType);
 	}
 }
 

--- a/Source/Wit/Private/Wit/Request/WitRequestBuilder.cpp
+++ b/Source/Wit/Private/Wit/Request/WitRequestBuilder.cpp
@@ -107,9 +107,9 @@ void FWitRequestBuilder::AddParameter(FWitRequestConfiguration& Configuration, c
  * @param Configuration [in,out] the request configuration to fill in
  * @param Format [in] the desired accept format
  */
-void FWitRequestBuilder::AddFormatAccept(FWitRequestConfiguration& Configuration, const EWitRequestFormat Format)
+void FWitRequestBuilder::AddFormatAccept(FWitRequestConfiguration& Configuration, const EWitRequestAudioFormat Format)
 {
-	Configuration.Accept = GetFormatString(Format);
+	Configuration.Accept = GetFormatAudioString(Format);
 }
 
 /**
@@ -315,6 +315,32 @@ const FString& FWitRequestBuilder::GetParameterKeyString(const EWitParameter Par
  *
  * @param Format the audio format
  * @return the string representation of the audio format
+ */
+const FString& FWitRequestBuilder::GetFormatAudioString(const EWitRequestAudioFormat Format)
+{
+	switch (Format)
+	{
+	case EWitRequestAudioFormat::Pcm:
+	{
+		return FormatValueRaw;
+	}
+	case EWitRequestAudioFormat::Wav:
+	{
+		return FormatValueWav;
+	}
+	default:
+	{
+		check(0);
+		return FormatValueWav;
+	}
+	}
+}
+
+/**
+ * Converts a request header value into its final string representation
+ *
+ * @param Format the request header value
+ * @return the string representation of the request header value
  */
 const FString& FWitRequestBuilder::GetFormatString(const EWitRequestFormat Format)
 {

--- a/Source/Wit/Private/Wit/Request/WitRequestBuilder.h
+++ b/Source/Wit/Private/Wit/Request/WitRequestBuilder.h
@@ -45,7 +45,7 @@ public:
 	 * @param Configuration [in,out] the request configuration to fill in
 	 * @param Format [in] the desired accept format
 	 */
-	static void AddFormatAccept(FWitRequestConfiguration& Configuration, const EWitRequestFormat Format);
+	static void AddFormatAccept(FWitRequestConfiguration& Configuration, const EWitRequestAudioFormat Format);
 
 	/**
 	 * Add an audio format content type. This is required when using the /speech endpoint
@@ -112,10 +112,18 @@ public:
 	static const FString& GetParameterKeyString(const EWitParameter ParameterKey);
 
 	/**
-     * Converts an audio format into its final string representation
+	 * Converts an audio format into its final string representation
+	 *
+	 * @param Format [in] the audio format
+	 * @return the string representation of the audio format
+	 */
+	static const FString& GetFormatAudioString(const EWitRequestAudioFormat Format);
+
+	/**
+     * Converts an header value into its final string representation
      *
-     * @param Format [in] the audio format
-     * @return the string representation of the audio format
+     * @param Format [in] the header value
+     * @return the string representation of the header value
      */
 	static const FString& GetFormatString(const EWitRequestFormat Format);
 

--- a/Source/Wit/Private/Wit/Request/WitRequestSubsystem.cpp
+++ b/Source/Wit/Private/Wit/Request/WitRequestSubsystem.cpp
@@ -370,7 +370,7 @@ void UWitRequestSubsystem::OnRequestComplete(FHttpRequestPtr Request, FHttpRespo
 	const FString ContentType = Response->GetContentType();
 
 	const bool bIsJsonContentType = ContentType.Contains(TEXT("application/json"));
-	const bool bIsAudioContentType = ContentType.Contains(TEXT("audio/wav"));
+	const bool bIsAudioContentType = ContentType.Contains(TEXT("audio/wav")) || ContentType.Contains(TEXT("audio/raw"));
 
 	UE_LOG(LogWit, Verbose, TEXT("OnRequestComplete: Content as string (%s)"), *Content);
 

--- a/Source/Wit/Private/Wit/TTS/WitTtsService.cpp
+++ b/Source/Wit/Private/Wit/TTS/WitTtsService.cpp
@@ -150,7 +150,7 @@ void UWitTtsService::ConvertTextToSpeechWithSettings(const FTtsConfiguration& Cl
 	FWitRequestBuilder::SetRequestConfigurationWithDefaults(RequestConfiguration, EWitRequestEndpoint::Synthesize, Configuration->Application.ClientAccessToken,
 		Configuration->Application.Advanced.ApiVersion, Configuration->Application.Advanced.URL);
 	FWitRequestBuilder::AddFormatContentType(RequestConfiguration, EWitRequestFormat::Json);
-	FWitRequestBuilder::AddFormatAccept(RequestConfiguration, EWitRequestFormat::Wav);
+	FWitRequestBuilder::AddFormatAccept(RequestConfiguration, AudioType);
 
 	RequestConfiguration.bShouldUseCustomHttpTimeout = Configuration->Application.Advanced.bIsCustomHttpTimeout;
 	RequestConfiguration.HttpTimeout = Configuration->Application.Advanced.HttpTimeout;

--- a/Source/Wit/Public/TTS/Experience/TtsExperience.h
+++ b/Source/Wit/Public/TTS/Experience/TtsExperience.h
@@ -11,6 +11,7 @@
 #include "GameFramework/Actor.h"
 #include "Tts/Service/TtsService.h"
 #include "Tts/Events/TtsEvents.h"
+#include "Wit/Request/WitRequestTypes.h"
 #include "Wit/Request/WitResponse.h"
 #include "TtsExperience.generated.h"
 
@@ -86,6 +87,12 @@ public:
 	 */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TTS")
 	UTtsVoicePresetAsset* VoicePreset{};
+
+	/**
+	 * The Wit TTS Audio Type that will be used by Wit.ai
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TTS")
+	EWitRequestAudioFormat AudioType{EWitRequestAudioFormat::Wav};
 	
 	/**
 	 * The events used by the voice service

--- a/Source/Wit/Public/TTS/Service/TtsService.h
+++ b/Source/Wit/Public/TTS/Service/TtsService.h
@@ -15,6 +15,7 @@
 #include "TTS/Cache/Storage/TtsStorageCacheHandler.h"
 #include "TTS/Configuration/TtsVoicePresetAsset.h"
 #include "TTS/Events/TtsEvents.h"
+#include "Wit/Request/WitRequestTypes.h"
 #include "TtsService.generated.h"
 
 /**
@@ -32,10 +33,14 @@ public:
 	/**
 	 * Set the configuration to use for TTS
 	 */
-	virtual void SetConfiguration(UWitAppConfigurationAsset* ConfigurationToUse, UTtsVoicePresetAsset* VoicePresetToUse)
+	virtual void SetConfiguration(
+		UWitAppConfigurationAsset* ConfigurationToUse,
+		UTtsVoicePresetAsset* VoicePresetToUse,
+		EWitRequestAudioFormat AudioTypeToUse)
 	{
 		Configuration = ConfigurationToUse;
 		VoicePreset = VoicePresetToUse;
+		AudioType = AudioTypeToUse;
 	}
 
 	/**
@@ -69,6 +74,12 @@ protected:
 	 */
 	UPROPERTY(Transient)
 	UTtsVoicePresetAsset* VoicePreset{};
+
+	/**
+	 * The Wit TTS Audio Type that will be used by Wit.ai
+	 */
+	UPROPERTY(Transient)
+	EWitRequestAudioFormat AudioType{EWitRequestAudioFormat::Wav};
 
 	/**
 	 * The events that this service should use in callbacks

--- a/Source/Wit/Public/Wit/Request/WitRequestTypes.h
+++ b/Source/Wit/Public/Wit/Request/WitRequestTypes.h
@@ -47,6 +47,16 @@ enum class EWitParameter : uint8
  * A list of the available audio formats for the /speech endpoint of Wit.ai.
  */
 UENUM()
+enum class EWitRequestAudioFormat : uint8
+{
+	Pcm,
+	Wav
+};
+
+/**
+ * A list of the available request header values for the /speech endpoint of Wit.ai.
+ */
+UENUM()
 enum class EWitRequestFormat : uint8
 {
 	Raw,

--- a/Source/Wit/Public/Wit/Utilities/WitHelperUtilities.h
+++ b/Source/Wit/Public/Wit/Utilities/WitHelperUtilities.h
@@ -164,4 +164,23 @@ private:
 
 	/** Additional user data to add to the end of user agent data in Wit requests */
 	static FString AdditionalEndUserData;
+
+	/** Struct that is used as a parameter to CreateSoundWaveFromParams */
+	struct FSoundWaveParams
+	{
+		float Duration{0};
+		uint32 SampleRate{24000};
+		int32 NumChannels{1};
+		float TotalSamples{0};
+		int32 RawDataSize{0};
+		const uint8* RawData{0};
+	};
+
+	/**
+	 * Creates a sound wave from paramerterized data
+	 *
+	 * @param SoundWaveParams [in] struct containing the data necessary to create a sound wave
+	 * @return the sound wave created or null if unsuccessful
+	 */
+	static USoundWave* CreateSoundWaveFromParams(const FSoundWaveParams& SoundWaveParams);
 };

--- a/Source/WitEditor/Private/Tool/SpeechGenerator/SWitSpeechGeneratorTab.cpp
+++ b/Source/WitEditor/Private/Tool/SpeechGenerator/SWitSpeechGeneratorTab.cpp
@@ -316,7 +316,7 @@ FReply SWitSpeechGeneratorTab::OnConvertButtonClicked()
 	UTtsService* TtsService = TtsExperience->TtsService;
 
 	TtsService->SetHandlers(TtsExperience->EventHandler, nullptr, nullptr);
-	TtsService->SetConfiguration(TtsExperience->Configuration, nullptr);
+	TtsService->SetConfiguration(TtsExperience->Configuration, nullptr, EWitRequestAudioFormat::Wav);
 	
 	TtsExperience->EventHandler->OnSynthesizeRawResponse.AddUniqueDynamic(EditedTextCollection, &UWitEditedTextCollection::OnSynthesizeRawResponse);
 	TtsExperience->EventHandler->OnSynthesizeError.AddUniqueDynamic(EditedTextCollection, &UWitEditedTextCollection::OnSynthesizeError);


### PR DESCRIPTION
- Added changes to allow PCM data to be successfully parsed and returned as a SoundWave.
- Created a new EWitRequestAudioFormat enum for available audio formats (EWitRequestFormat contained Json as well, which would have been confusing in the dropdown).
- Exposed the audio format selection to users via TtsExperience