### PR TITLE
Enable Splitting speech

### DIFF
--- a/Source/Wit/Private/Wit/Utilities/WitTtsSpeechSplitter.cpp
+++ b/Source/Wit/Private/Wit/Utilities/WitTtsSpeechSplitter.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "Wit/Utilities/WitTtsSpeechSplitter.h"
+#include "Wit/Utilities/WitLog.h"
+#include "Internationalization/Regex.h"
+
+/**
+ * Checks whether or not a string needs to be split
+ *
+ * @param Speech [in] String of speech
+ * @param MaxSize [in] The maximum size of text per portion
+ */
+bool FWitTtsSpeechSplitter::NeedsSplit(const FString Speech, const int32 MaxSize)
+{
+	return (Speech.Len() > MaxSize);
+}
+
+/**
+ * Splits a given string into portions
+ *
+ * @param Speech [in] String of speech
+ * @param MaxSize [in] The maximum size of text per portion
+ * @return Array of FStrings split portions
+ */
+TArray<FString> FWitTtsSpeechSplitter::SplitSpeech(const FString Speech, const int32 MaxSize)
+{
+	TArray<FString> SplitResult;
+
+	const FRegexPattern SentencePattern = FRegexPattern(TEXT("\\.|\\,|\\?|\\;|\\:|\\!"));
+	FRegexMatcher Matcher = FRegexMatcher(SentencePattern, Speech);
+	int32 LastStart = 0;
+	while (Matcher.FindNext())
+	{
+		int32 Ending = Matcher.GetMatchEnding();
+
+		FString Sentence = Speech.Mid(LastStart, Ending - LastStart);
+
+		if (Sentence.Len() > MaxSize)
+		{
+			TArray<FString> Words = SplitSentence(Sentence);
+			for (int32 i = 0; i < Words.Num(); i++)
+			{
+				SplitResult.Add(Words[i]);
+			}
+		}
+		else
+		{
+			SplitResult.Add(Sentence);
+		}
+		LastStart = Ending;
+	}
+	FString Sentence = Speech.Mid(LastStart, Speech.Len());
+
+	if (Sentence.Len() > MaxSize)
+	{
+		TArray<FString> Words = SplitSentence(Sentence);
+		for (int32 i = 0; i < Words.Num(); i++)
+		{
+			SplitResult.Add(Words[i]);
+		}
+	}
+	else
+	{
+		SplitResult.Add(Sentence);
+	}
+
+	return CombineText(SplitResult, MaxSize);
+}
+
+/**
+ * Splits a given sentence into words
+ *
+ * @param Sentence [in] A string of words
+ * @return Array of FStrings split words
+ */
+TArray<FString> FWitTtsSpeechSplitter::SplitSentence(const FString Sentence)
+{
+	TArray<FString> SplitResult;
+	const FRegexPattern WordPattern = FRegexPattern(TEXT("\\s"));
+
+	FRegexMatcher Matcher = FRegexMatcher(WordPattern, Sentence);
+	int32 LastStart = 0;
+	while (Matcher.FindNext())
+	{
+		int32 Ending = Matcher.GetMatchEnding();
+
+		FString Word = Sentence.Mid(LastStart, Ending - LastStart);
+
+		SplitResult.Add(Word);
+		LastStart = Ending;
+	}
+	FString Word = Sentence.Mid(LastStart, Sentence.Len());
+	SplitResult.Add(Word);
+
+	return SplitResult;
+}
+
+/**
+ * Combines portions of text together that are no larger than a given size
+ *
+ * @param Portions [in] a series of fragements
+ * @param MaxSize [in] The maximum size of text per portion
+ * @return Array of FStrings combined portions
+ */
+TArray<FString> FWitTtsSpeechSplitter::CombineText(const TArray<FString> Portions, const int32 MaxSize)
+{
+	TArray<FString> CombinedText;
+	FString CurrentText;
+	for (FString Portion : Portions)
+	{
+		FString TempText = CurrentText + Portion;
+		if (TempText.Len() > MaxSize)
+		{
+			CombinedText.Add(CurrentText);
+			CurrentText = Portion;
+		}
+		else
+		{
+			CurrentText = TempText;
+		}
+	}
+	CombinedText.Add(CurrentText);
+	return CombinedText;
+}

--- a/Source/Wit/Private/Wit/Utilities/WitTtsSpeechSplitter.h
+++ b/Source/Wit/Private/Wit/Utilities/WitTtsSpeechSplitter.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+ /**
+  * A helper class that contains utilities for splitting strings of speech
+  */
+class FWitTtsSpeechSplitter
+{
+public:
+	/**
+	 * Checks whether or not a string needs to be split
+	 * 
+	 * @param Speech [in] String of speech
+	 * @param MaxSize [in] The maximum size of text per portion
+	 */
+	static bool NeedsSplit(const FString Speech, const int32 MaxSize);
+
+	/**
+	 * Splits a given string into portions
+	 *
+	 * @param Speech [in] String of speech
+	 * @param MaxSize [in] The maximum size of text per portion
+	 * @return Array of FStrings split portions 
+	 */
+	static TArray<FString> SplitSpeech(const FString Speech, const int32 MaxSize);
+
+protected:
+	/**
+	 * Splits a given sentence into words
+	 *
+	 * @param Sentence [in] A string of words
+	 * @return Array of FStrings split words
+	 */
+	static TArray<FString> SplitSentence(const FString Sentence);
+
+	/**
+	 * Combines portions of text together that are no larger than a given size
+	 *
+	 * @param Portions [in] a series of fragements
+	 * @param MaxSize [in] The maximum size of text per portion
+	 * @return Array of FStrings combined portions
+	 */
+	static TArray<FString> CombineText(const TArray<FString> Portions, const int32 MaxSize);
+};

--- a/Source/Wit/Public/TTS/Service/Interface/ITtsServiceBase.h
+++ b/Source/Wit/Public/TTS/Service/Interface/ITtsServiceBase.h
@@ -40,7 +40,7 @@ public:
 	 * Sends a text string to Wit for conversion to speech with custom settings
 	 *
 	 * @param ClipSettings [in] the string we want to convert to speech
-	  * @param QueueAudio [in] should audio be placed in a queue
+	 * @param QueueAudio [in] should audio be placed in a queue
 	 */
 	virtual void ConvertTextToSpeechWithSettings(const FTtsConfiguration& ClipSettings, bool bQueueAudio = true) = 0;
 

--- a/Source/Wit/Public/Wit/TTS/WitTtsService.h
+++ b/Source/Wit/Public/Wit/TTS/WitTtsService.h
@@ -81,18 +81,40 @@ private:
 	/** Previous data index used to process raw data */
 	int32 PreviousDataIndex{0};
 
+	/** Stop the request that is currently in progress */
+	bool bStopInProgressRequest;
+
+	/** Clip settings enqueued */
+	TArray<FTtsConfiguration> QueuedSettings;
+
 #if WITH_EDITORONLY_DATA
 	
 	/** Write the captured voice input to a wav file */
 	static void WriteRawPCMDataToWavFile(const uint8* RawPCMData, const int32 RawPCMDataSize, const int32 NumChannels, const int32 SampleRate);
 
 #endif
+
+	/**
+	 * Sends a text string to Wit for conversion to speech with custom settings
+	 *
+	 * @param NewRequest [in] is this a new request or the next piece of a split request
+	 * @param QueueAudio [in] should audio be placed in a queue
+	 */
+	void ConvertTextToSpeechWithSettingsInternal(const bool bNewRequest, const bool bQueueAudio);
+
+	/**
+	 * Splits a speech segment into smaller segments
+	 *
+	 * @param ClipSettings [in] the string we want to convert to speech
+	 * @param QueueAudio [in] should audio be placed in a queue
+	 */
+	void SplitSpeech(const FTtsConfiguration& ClipSettings, const bool bQueueAudio);
 	
 	/** Called when a storage cache request is fully completed to process the loaded data */
 	void OnStorageCacheRequestComplete(const TArray<uint8>& BinaryData, const FTtsConfiguration& ClipSettings) const;
 
 	/** Called when a Wit synthesize request is fully completed to process the response payload */
-	void OnSynthesizeRequestComplete(const TArray<uint8>& BinaryResponse, const TSharedPtr<FJsonObject> JsonResponse) const;
+	void OnSynthesizeRequestComplete(const TArray<uint8>& BinaryResponse, const TSharedPtr<FJsonObject> JsonResponse);
 
 	/** Called when a synthesize request errors */
 	void OnSynthesizeRequestError(const FString& ErrorMessage, const FString& HumanReadableErrorMessage) const;

--- a/Source/Wit/Public/Wit/TTS/WitTtsSpeaker.h
+++ b/Source/Wit/Public/Wit/TTS/WitTtsSpeaker.h
@@ -80,8 +80,6 @@ protected:
 	*/
 	TArray<USoundWave*> SoundWaveQueue{};
 
-	bool bQueueingEnabled{true};
-
 	virtual void BeginPlay() override;
 	virtual void BeginDestroy() override;
 	


### PR DESCRIPTION
Added logic to split a speech string into substrings if it is larger than the maximum length allowed. First check is on punctuation delimiters, and if none found the text is split by word.
![SpeechSplitting](https://github.com/wit-ai/wit-unreal/assets/146737714/75a7413b-7e5b-4368-a0d6-839a246187af)

https://github.com/wit-ai/wit-unreal/assets/146737714/e4590182-1dad-4b99-9cd1-07bea388aa14

