### PR TITLE
Remove restriction on ComposerExperience

### DIFF
--- a/Source/Wit/Public/Wit/Composer/WitComposerExperience.h
+++ b/Source/Wit/Public/Wit/Composer/WitComposerExperience.h
@@ -17,7 +17,7 @@
 /**
  * Top level actor for Wit composer interactions
  */
-UCLASS( ClassGroup=(Meta), NotPlaceable )
+UCLASS( ClassGroup=(Meta) )
 class WIT_API AWitComposerExperience final : public AActor
 {
 	GENERATED_BODY()


### PR DESCRIPTION
Composer Experience is currently set to NotPlaceable preventing it from being added into levels. This change removes that restriction so that a Compose sample can be created.